### PR TITLE
Updated doc regarding recent prisma changes.

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ We use Python for data science, leveraging a number of powerful libraries for da
 
 ## Architecture
 
-The data model/DB schema lives in `prisma/schema`, server side code and some utils are in `nexus/`, and front end code constitutes most the rest of the directories. `graphql/` holds the _frontend_ graphql queries.
+The data model/DB schema lives in `j-db-client/prisma/schema`, server side code and some utils are in `nexus/`, and front end code constitutes most the rest of the directories. `graphql/` holds the _frontend_ graphql queries.
 
 ---
 
@@ -57,9 +57,9 @@ The data model/DB schema lives in `prisma/schema`, server side code and some uti
    $ alter user <your_username> with superuser;
    ```
 
-1. If you haven't created a `prisma/.env` file yet, copy and paste `prisma/.env.example` into `prisma/.env`. Then, replace the placeholders in both `prisma/.env` and the `.env` file in the root of the project with your new postgres username & password.
+2. Update your `.env` file with your new postgres username & password. Copy and paste your root `.env` into `j-db-client/prisma/.env`. You should end up with two of the same file, one in root and the other in `j-db-client`.
 
-1. Finally, from the `prisma` directory, apply database migrations to your new database instance:
+3. Finally, from the `j-db-client` directory, apply database migrations to your new database instance:
 
    ```bash
    $ npm run migrate:up
@@ -83,7 +83,7 @@ $ npm run migrate:save
 $ npm run migrate:up
 ```
 
-The first command creates a migration, resulting in a new file in the `prisma/migrations` directory. The second applies that migration to the local database. You'll want to commit any new migration artifacts that you create. Previous migrations should never be edited.
+The first command creates a migration, resulting in a new file in the `j-db-client/prisma/migrations` directory. The second applies that migration to the local database. You'll want to commit any new migration artifacts that you create. Previous migrations should never be edited.
 
 ### Running Journaly
 


### PR DESCRIPTION
## Update to `README.md`

Request to update the `README.md` documentation to reflect recent changes to prisma implementation. Current language references the `prisma` directory as being directly in root, but it is actually under `j-db-client`. The instructions around the `.env` file were slightly confusing, so I cleaned those up as well to be a bit more straight forward.

Details of the issue mention being able to run commands from root as well as the `prisma` folder (which actually need to be run from `j-db-client`). While some of the npm scripts can run from root, I found `npm run migrate:up` had to be specifically run from the `j-db-client` folder. It would be nice to eliminate the need for the duplicated environment file, but I'm new to a lot of this and not quite sure how to make that work.

Documentation is at least correct for the current state of the repo.

**Issue:** #430

...

https://www.journaly.com/dashboard/profile/3068